### PR TITLE
Ensure "SHOW CLUSTER '{cluster}'" works

### DIFF
--- a/src/Interpreters/InterpreterShowTablesQuery.cpp
+++ b/src/Interpreters/InterpreterShowTablesQuery.cpp
@@ -58,7 +58,7 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
         return rewritten_query.str();
     }
 
-    /// SHOW CLUSTER/CLUSTERS
+    /// SHOW CLUSTERS
     if (query.clusters)
     {
         WriteBufferFromOwnString rewritten_query;
@@ -81,12 +81,16 @@ String InterpreterShowTablesQuery::getRewrittenQuery()
 
         return rewritten_query.str();
     }
+
+    /// SHOW CLUSTER
     if (query.cluster)
     {
         WriteBufferFromOwnString rewritten_query;
         rewritten_query << "SELECT * FROM system.clusters";
-
-        rewritten_query << " WHERE cluster = " << DB::quote << query.cluster_str;
+        
+        auto cluster_name_expanded = getContext()->getMacros()->expand(query.cluster_str);
+        
+        rewritten_query << " WHERE cluster = " << DB::quote << cluster_name_expanded;
 
         /// (*)
         rewritten_query << " ORDER BY cluster, shard_num, replica_num, host_name, host_address, port";


### PR DESCRIPTION
Most places that accept a cluster name, like
    
    CREATE ... ON CLUSTER 'cluster_name'
    
or
    
    SELECT * FROM cluster('cluster_name', db.table)
    
accepts (and expands) a string with macros like '{cluster}'. This change ensures a similar behavior with "SHOW CLUSTER".

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- Improvement


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- the "SHOW CLUSTER" statement now expands macros (if any) in its argument

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
